### PR TITLE
V3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [3.0.2] - 2026-05-25
+
+### Changed
+
+- Switched outdated reference to the Twig template engine to Latte in README.md.
+
+### Removed
+
+- README.md: Removed a section about the use of the static `Router::getRoute()` since this was removed in *fhooe/router*
+  3.0.0.
+
 ## [3.0.1] - 2026-05-10
 
 ### Changed
@@ -161,7 +172,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added notes on Contributing.
 - Added this changelog.
 
-[Unreleased]: https://github.com/Digital-Media/fhooe-router-skeleton/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/Digital-Media/fhooe-router-skeleton/compare/v3.0.2...HEAD
+[3.0.2]: https://github.com/Digital-Media/fhooe-router-skeleton/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Digital-Media/fhooe-router-skeleton/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/Digital-Media/fhooe-router-skeleton/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/Digital-Media/fhooe-router-skeleton/compare/v1.0.1...v2.0.0

--- a/README.md
+++ b/README.md
@@ -76,36 +76,14 @@ The router invocation happens in `public/index.php`. This front controller file 
    $router->run();
    ```
 
-### Using the Static Routing Method `Router::getRoute()`
-
-1. Invoke the static method. Provide a base path as an argument if your project is not located in your server's document root. The method returns the route as a string in the form of `METHOD /pattern` , e.g., `GET /`, when a GET request was made to the root directory.
-
-   ```php
-   $route = Router::getRoute("/path/to/your/files");
-   ```
-
-2. Use a conditional expression to decide what to do with the matched route.
-
-   ```php
-   switch($route) {
-       case "GET /":
-           // e.g., load a view
-           break;
-       default:
-           // e.g., load the 404 view
-           break;
-   }
-   ```
-
 ## Displaying Output
 
-Simple example view files in the form of HTML and PHP files are located in the `views` directory together with [Twig](https://packagist.org/packages/twig/twig) examples for cleaner output.
+Simple example view files in the form of HTML and PHP files are located in the `views` directory together with [Latte](https://packagist.org/packages/latte/latte) examples for cleaner output.
 
-Three Twig extensions have been added.
+Two [Latte extensions](https://packagist.org/packages/fhooe/latte-extensions) have been added.
 
 - `RouterExtension` provides the functions `url_for()` and `get_base_path()` in templates for generating URLs and retrieving the base path from the `Router` object.
 - `SessionExtension` provides the function `session(key)` for retrieving entries in the `$_SESSION` superglobal.
-- `DebugExtension` provides the function `dump()` for dumping variables in templates (similar to `var_dump()`).
 
 ## Browsing the Application
 


### PR DESCRIPTION
### Changed

- Switched outdated reference to the Twig template engine to Latte in README.md.

### Removed

- README.md: Removed a section about the use of the static `Router::getRoute()` since this was removed in *fhooe/router*
  3.0.0.